### PR TITLE
Add Asset-Component Overview Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "hitu",
+  "description": "Hitu is a React component to generate motion-able React design artist.",
+  "scripts": {
+    "lint": "echo \"No linter yet.\"",
+    "coverage": "echo \"No tests yet.\""
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ant-design/HiTu.git"
+  },
+  "author": "",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/ant-design/HiTu/issues"
+  },
+  "homepage": "https://github.com/ant-design/HiTu#readme"
+}

--- a/packages/hitu-assets/examples/background-components.tsx
+++ b/packages/hitu-assets/examples/background-components.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import * as AllAssets from '../src';
+import ComponentWrapper from './common/ComponentWrapper';
+
+export default () => {
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+      {Object.keys(AllAssets)
+        .filter(name => name.startsWith('Background'))
+        .map(name => {
+          const Component = AllAssets[name];
+          return (
+            <ComponentWrapper key={name} name={name}>
+              <Component width="100%" height="auto" />
+            </ComponentWrapper>
+          );
+        })}
+    </div>
+  );
+};

--- a/packages/hitu-assets/examples/character-components.tsx
+++ b/packages/hitu-assets/examples/character-components.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import * as AllAssets from '../src';
+import ComponentWrapper from './common/ComponentWrapper';
+
+export default () => {
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+      {Object.keys(AllAssets)
+        .filter(name => name.includes('Character'))
+        .map(name => {
+          const Component = AllAssets[name];
+          return (
+            <ComponentWrapper key={name} name={name}>
+              <Component width="100%" height="auto" />
+            </ComponentWrapper>
+          );
+        })}
+    </div>
+  );
+};

--- a/packages/hitu-assets/examples/common-components.tsx
+++ b/packages/hitu-assets/examples/common-components.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import * as AllAssets from '../src';
+import ComponentWrapper from './common/ComponentWrapper';
+
+export default () => {
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+      {Object.keys(AllAssets)
+        .filter(name => name.includes('Common'))
+        .map(name => {
+          const Component = AllAssets[name];
+          return (
+            <ComponentWrapper key={name} name={name}>
+              <Component width="100%" height="auto" />
+            </ComponentWrapper>
+          );
+        })}
+    </div>
+  );
+};

--- a/packages/hitu-assets/examples/common/ComponentWrapper.tsx
+++ b/packages/hitu-assets/examples/common/ComponentWrapper.tsx
@@ -1,0 +1,34 @@
+import { CSSProperties, FC } from 'react';
+
+const WRAPPER_STYLE: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  textAlign: 'center',
+  width: 250,
+  overflow: 'hidden',
+};
+
+const NAME_STYLE: CSSProperties = {
+  display: 'inline-block',
+  // antd font family
+  fontFamily: "-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, 'Noto Sans', sans- serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'",
+  fontSize: 12
+};
+
+type ComponentWrapperProps = {
+  name: string;
+};
+
+const ComponentWrapper: FC<ComponentWrapperProps> = ({
+  children,
+  name
+}) => (
+  <div style={WRAPPER_STYLE}>
+    {children}
+    <span style={NAME_STYLE}>
+      {name}
+    </span>
+  </div>
+);
+
+export default ComponentWrapper;


### PR DESCRIPTION
There was no possibility to have an overview of all asset components. Now there is.
This is the first step in the direction of a documentation page: #5 


I have added 3 new pages to the storybook:
1. background-components
2. character-components
3. common-components

The pages look like this:

![image](https://user-images.githubusercontent.com/11338472/126634236-0aab6edd-ca73-4f6a-b702-c721c241e1b8.png)

![image](https://user-images.githubusercontent.com/11338472/126634626-8673a7e5-c554-4302-a3b3-9b12683662ac.png)
